### PR TITLE
feat: add room rename with worktree folder move

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -4,8 +4,10 @@ mod create;
 mod naming;
 mod post_create;
 mod remove;
+mod rename;
 
 pub use create::{create_room, CreateRoomError, CreateRoomOptions};
 pub use naming::generate_room_name;
 pub use post_create::{run_post_create_commands, PostCreateHandle, PostCreateResult};
 pub use remove::{remove_room, DirtyStatus, RemoveRoomError};
+pub use rename::{rename_room, RenameRoomError};

--- a/src/room/rename.rs
+++ b/src/room/rename.rs
@@ -1,0 +1,266 @@
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::git::command::GitCommand;
+use crate::room::naming::validate_room_name;
+use crate::state::RoomsState;
+
+#[derive(Error, Debug)]
+pub enum RenameRoomError {
+    #[error("room '{0}' not found")]
+    NotFound(String),
+
+    #[error("invalid name: {0}")]
+    InvalidName(&'static str),
+
+    #[error("a room named '{0}' already exists")]
+    NameExists(String),
+
+    #[error("new name is the same as current name")]
+    SameName,
+
+    #[error("destination path already exists: {0}")]
+    PathExists(String),
+
+    #[error("failed to move worktree: {0}")]
+    WorktreeMove(String),
+}
+
+/// Rename a room.
+///
+/// This changes:
+/// - The room's display name in state
+/// - The worktree directory (via `git worktree move`)
+///
+/// The git branch name remains unchanged.
+pub fn rename_room(
+    repo_root: &Path,
+    rooms_dir: &Path,
+    state: &mut RoomsState,
+    current_name: &str,
+    new_name: &str,
+) -> Result<String, RenameRoomError> {
+    // Validate new name
+    validate_room_name(new_name).map_err(RenameRoomError::InvalidName)?;
+
+    // Check if same name
+    if current_name == new_name {
+        return Err(RenameRoomError::SameName);
+    }
+
+    // Check if new name already exists in state
+    if state.name_exists(new_name) {
+        return Err(RenameRoomError::NameExists(new_name.to_string()));
+    }
+
+    // Find the room to get its current path
+    let room = state
+        .find_by_name(current_name)
+        .ok_or_else(|| RenameRoomError::NotFound(current_name.to_string()))?;
+
+    let old_path = room.path.clone();
+    let new_path = rooms_dir.join(new_name);
+
+    // Check if destination path already exists on filesystem
+    if new_path.exists() {
+        return Err(RenameRoomError::PathExists(
+            new_path.to_string_lossy().to_string(),
+        ));
+    }
+
+    // Move the worktree using git (must be run from repo root)
+    let result = GitCommand::new("worktree")
+        .args(&["move", &old_path.to_string_lossy(), &new_path.to_string_lossy()])
+        .current_dir(repo_root)
+        .run()
+        .map_err(|e| RenameRoomError::WorktreeMove(e.to_string()))?;
+
+    if !result.success() {
+        return Err(RenameRoomError::WorktreeMove(result.stderr));
+    }
+
+    // Update the room in state
+    let room = state
+        .find_by_name_mut(current_name)
+        .ok_or_else(|| RenameRoomError::NotFound(current_name.to_string()))?;
+
+    let old_name = room.name.clone();
+    room.name = new_name.to_string();
+    room.path = new_path;
+
+    Ok(old_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{Room, RoomStatus};
+    use std::path::PathBuf;
+    use std::process::Command;
+    use uuid::Uuid;
+
+    fn create_test_room(name: &str, path: PathBuf) -> Room {
+        Room {
+            id: Uuid::new_v4(),
+            name: name.to_string(),
+            branch: name.to_string(),
+            path,
+            created_at: chrono::Utc::now(),
+            last_used_at: chrono::Utc::now(),
+            status: RoomStatus::Ready,
+            last_error: None,
+        }
+    }
+
+    fn setup_test_repo() -> (tempfile::TempDir, PathBuf) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().to_path_buf();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+
+        Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+
+        (temp_dir, repo_path)
+    }
+
+    #[test]
+    fn test_rename_room_not_found() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_root = temp_dir.path();
+        let rooms_dir = temp_dir.path();
+        let mut state = RoomsState::default();
+
+        let result = rename_room(repo_root, rooms_dir, &mut state, "nonexistent", "new-name");
+        assert!(matches!(result, Err(RenameRoomError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_rename_room_invalid_name() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_root = temp_dir.path();
+        let rooms_dir = temp_dir.path();
+        let mut state = RoomsState::default();
+        state
+            .rooms
+            .push(create_test_room("old-name", rooms_dir.join("old-name")));
+
+        let result = rename_room(repo_root, rooms_dir, &mut state, "old-name", "Invalid Name");
+        assert!(matches!(result, Err(RenameRoomError::InvalidName(_))));
+    }
+
+    #[test]
+    fn test_rename_room_name_exists() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_root = temp_dir.path();
+        let rooms_dir = temp_dir.path();
+        let mut state = RoomsState::default();
+        state
+            .rooms
+            .push(create_test_room("room-a", rooms_dir.join("room-a")));
+        state
+            .rooms
+            .push(create_test_room("room-b", rooms_dir.join("room-b")));
+
+        let result = rename_room(repo_root, rooms_dir, &mut state, "room-a", "room-b");
+        assert!(matches!(result, Err(RenameRoomError::NameExists(_))));
+    }
+
+    #[test]
+    fn test_rename_room_same_name() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_root = temp_dir.path();
+        let rooms_dir = temp_dir.path();
+        let mut state = RoomsState::default();
+        state
+            .rooms
+            .push(create_test_room("my-room", rooms_dir.join("my-room")));
+
+        let result = rename_room(repo_root, rooms_dir, &mut state, "my-room", "my-room");
+        assert!(matches!(result, Err(RenameRoomError::SameName)));
+    }
+
+    #[test]
+    fn test_rename_room_with_worktree() {
+        let (_temp_dir, repo_path) = setup_test_repo();
+        let rooms_dir = repo_path.join(".rooms");
+        std::fs::create_dir_all(&rooms_dir).unwrap();
+
+        // Create a worktree
+        let old_path = rooms_dir.join("old-name");
+        Command::new("git")
+            .args(["worktree", "add", "-b", "old-name", &old_path.to_string_lossy()])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+
+        let mut state = RoomsState::default();
+        state.rooms.push(create_test_room("old-name", old_path.clone()));
+
+        // Rename the room
+        let result = rename_room(&repo_path, &rooms_dir, &mut state, "old-name", "new-name");
+        assert!(result.is_ok(), "rename failed: {:?}", result.err());
+        assert_eq!(result.unwrap(), "old-name");
+
+        // Verify state was updated
+        let room = state.find_by_name("new-name");
+        assert!(room.is_some());
+        let room = room.unwrap();
+        assert_eq!(room.name, "new-name");
+        assert_eq!(room.path, rooms_dir.join("new-name"));
+
+        // Verify old name no longer exists
+        assert!(state.find_by_name("old-name").is_none());
+
+        // Verify filesystem was updated
+        assert!(!old_path.exists());
+        assert!(rooms_dir.join("new-name").exists());
+    }
+
+    #[test]
+    fn test_rename_room_path_exists() {
+        let (_temp_dir, repo_path) = setup_test_repo();
+        let rooms_dir = repo_path.join(".rooms");
+        std::fs::create_dir_all(&rooms_dir).unwrap();
+
+        // Create a worktree
+        let old_path = rooms_dir.join("old-name");
+        Command::new("git")
+            .args(["worktree", "add", "-b", "old-name", &old_path.to_string_lossy()])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+
+        // Create a directory at the destination path
+        let new_path = rooms_dir.join("new-name");
+        std::fs::create_dir_all(&new_path).unwrap();
+
+        let mut state = RoomsState::default();
+        state.rooms.push(create_test_room("old-name", old_path));
+
+        let result = rename_room(&repo_path, &rooms_dir, &mut state, "old-name", "new-name");
+        assert!(matches!(result, Err(RenameRoomError::PathExists(_))));
+    }
+}

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -15,6 +15,8 @@ pub enum EventType {
     RoomCreated,
     /// A room was deleted.
     RoomDeleted,
+    /// A room was renamed.
+    RoomRenamed,
     /// Post-create commands started.
     PostCreateStarted,
     /// Post-create commands completed successfully.
@@ -119,6 +121,14 @@ impl EventLog {
     /// Log a room deletion event.
     pub fn log_room_deleted(&self, room_name: &str) {
         let event = Event::new(EventType::RoomDeleted).with_room(room_name);
+        let _ = self.log(event);
+    }
+
+    /// Log a room rename event.
+    pub fn log_room_renamed(&self, old_name: &str, new_name: &str) {
+        let event = Event::new(EventType::RoomRenamed)
+            .with_room(new_name)
+            .with_details(format!("{} -> {}", old_name, new_name));
         let _ = self.log(event);
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use crate::config::Config;
 use crate::git::Worktree;
-use crate::room::{create_room, remove_room, run_post_create_commands, CreateRoomOptions, DirtyStatus, PostCreateHandle};
+use crate::room::{create_room, remove_room, rename_room, run_post_create_commands, CreateRoomOptions, DirtyStatus, PostCreateHandle};
 use crate::state::{EventLog, RoomStatus, RoomsState};
 use crate::terminal::PtySession;
 
@@ -390,6 +390,15 @@ impl App {
                 self.prompt.cancel();
             }
             KeyCode::Enter => {
+                // Handle RenameRoom separately (single-step prompt)
+                if let PromptState::RenameRoom { current_name, input } = &self.prompt {
+                    let old_name = current_name.clone();
+                    let new_name = input.value.clone();
+                    self.prompt = PromptState::None;
+                    self.apply_room_rename(&old_name, &new_name);
+                    return;
+                }
+
                 if let Some((room_name, branch_name)) = self.prompt.advance() {
                     // Prompt complete, create the room
                     self.create_room_interactive(room_name, branch_name);
@@ -458,6 +467,9 @@ impl App {
             }
             KeyCode::Char('d') => {
                 self.start_room_deletion();
+            }
+            KeyCode::Char('r') => {
+                self.start_room_rename();
             }
             _ => {}
         }
@@ -776,6 +788,55 @@ impl App {
             Err(e) => {
                 self.status_message = Some(format!("Failed to delete room: {}", e));
                 self.event_log.log_error(Some(room_name), &e.to_string());
+            }
+        }
+    }
+
+    /// Start the room rename flow.
+    fn start_room_rename(&mut self) {
+        let room = match self.selected_room() {
+            Some(r) => r,
+            None => {
+                self.status_message = Some("No room selected".to_string());
+                return;
+            }
+        };
+
+        let current_name = room.name.clone();
+        self.prompt = PromptState::start_room_rename(current_name);
+    }
+
+    /// Apply a room rename.
+    fn apply_room_rename(&mut self, old_name: &str, new_name: &str) {
+        // Skip if new name is empty
+        if new_name.is_empty() {
+            self.status_message = Some("Rename cancelled: name cannot be empty".to_string());
+            return;
+        }
+
+        // Get room ID before rename to clean up session afterward
+        let room_id = self.state.find_by_name(old_name).map(|r| r.id);
+
+        match rename_room(&self.repo_root, &self.rooms_dir, &mut self.state, old_name, new_name) {
+            Ok(_) => {
+                // Remove PTY session since the working directory changed
+                if let Some(id) = room_id {
+                    self.sessions.remove(&id);
+                }
+
+                // Log the event
+                self.event_log.log_room_renamed(old_name, new_name);
+
+                // Save state
+                if let Err(e) = self.state.save_to_rooms_dir(&self.rooms_dir) {
+                    self.status_message = Some(format!("Room renamed but failed to save: {}", e));
+                } else {
+                    self.status_message = Some(format!("Renamed: {} -> {}", old_name, new_name));
+                }
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Failed to rename room: {}", e));
+                self.event_log.log_error(Some(old_name), &e.to_string());
             }
         }
     }

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -101,12 +101,31 @@ pub enum PromptState {
         room_name: Option<String>,
         input: TextInput,
     },
+
+    /// Prompting for new room name (rename).
+    RenameRoom {
+        /// Original name (for lookup during save).
+        current_name: String,
+        /// Text input pre-filled with current name.
+        input: TextInput,
+    },
 }
 
 impl PromptState {
     /// Start prompting for a new room.
     pub fn start_room_creation() -> Self {
         Self::RoomName(TextInput::new("Leave empty for generated name"))
+    }
+
+    /// Start prompting for a room rename.
+    pub fn start_room_rename(current_name: String) -> Self {
+        let mut input = TextInput::new("");
+        input.value = current_name.clone();
+        input.cursor = input.value.len(); // Cursor at end
+        Self::RenameRoom {
+            current_name,
+            input,
+        }
     }
 
     /// Check if a prompt is active.
@@ -120,11 +139,13 @@ impl PromptState {
             Self::None => None,
             Self::RoomName(input) => Some(input),
             Self::BranchName { input, .. } => Some(input),
+            Self::RenameRoom { input, .. } => Some(input),
         }
     }
 
     /// Advance to the next prompt step, returning the final result if done.
     /// Returns Some((room_name, branch_name)) when complete.
+    /// Note: RenameRoom is handled separately and should not use this method.
     pub fn advance(&mut self) -> Option<(Option<String>, Option<String>)> {
         match std::mem::take(self) {
             Self::None => None,
@@ -141,6 +162,11 @@ impl PromptState {
                 *self = Self::None;
                 Some((room_name, branch_name))
             }
+            Self::RenameRoom { .. } => {
+                // RenameRoom is handled directly in handle_prompt_key, not via advance()
+                *self = Self::None;
+                None
+            }
         }
     }
 
@@ -156,6 +182,7 @@ pub fn render_prompt(frame: &mut Frame, area: Rect, prompt: &PromptState) {
         PromptState::None => return,
         PromptState::RoomName(input) => ("Create Room - Name", "Enter room name:", input),
         PromptState::BranchName { input, .. } => ("Create Room - Branch", "Enter branch name:", input),
+        PromptState::RenameRoom { input, .. } => ("Rename Room", "Enter new name:", input),
     };
 
     // Center the prompt


### PR DESCRIPTION
## Summary
- Add ability to rename a room by pressing `r` in the sidebar
- Moves the worktree folder using `git worktree move` (branch name unchanged)
- Prompts for new name, pre-filled with current room name
- Closes active PTY session after rename (will restart in new location)

## Test plan
- [ ] Run `cargo test` - all 58 tests pass
- [ ] Start the app with `cargo run`
- [ ] Create a room (press `a` or `A`)
- [ ] Select the room and press `r`
- [ ] Verify prompt shows with current name pre-filled
- [ ] Enter a new name and press Enter
- [ ] Verify room name updates in sidebar
- [ ] Verify folder moved in `.rooms/` directory
- [ ] Verify event logged in `.rooms/events.log`
- [ ] Press Escape on rename prompt to verify cancel works

🤖 Generated with [Claude Code](https://claude.com/claude-code)