### PR TITLE
feat(terminal): add bracketed paste mode and Alt+Enter support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,15 @@
 You are implementing `rooms`, a Rust + ratatui terminal UI to manage Git worktrees ("rooms").
 Repository: https://github.com/felipeplets/rooms
 
+## Worktree Context
+
+**CRITICAL**: Always work within the current worktree directory where you were initiated. This project uses git worktrees for development, and each worktree is an independent working copy:
+
+- Check your current working directory at the start of any session
+- All file edits, reads, and operations must use paths within the current worktree
+- Never modify files in the parent repository or other worktrees
+- The current worktree path pattern is: `.rooms/<worktree-name>/`
+
 ## Non-negotiable rules
 1. Privacy-first: DO NOT add telemetry. DO NOT add network calls. Everything is local-only.
 2. Transparency: Every action must surface state transitions in the UI and a local event log.

--- a/reqs/4-keybindings.md
+++ b/reqs/4-keybindings.md
@@ -44,6 +44,7 @@ Standard keys are translated to terminal escape sequences:
 | Key | Sequence |
 |-----|----------|
 | `Enter` | `\r` |
+| `Alt+Enter` | `ESC + \r` (literal newline in shell) |
 | `Backspace` | `0x7f` |
 | `Tab` | `\t` |
 | Arrow keys | VT100 escape sequences |

--- a/reqs/8-pseudoterminal.md
+++ b/reqs/8-pseudoterminal.md
@@ -55,6 +55,19 @@ These keys are NOT forwarded to the PTY:
 - `Ctrl+b` (toggles sidebar)
 - `Ctrl+t` (toggles terminal)
 
+### Bracketed Paste Mode
+
+- Enabled on terminal startup for proper multi-line paste handling
+- Pasted content is wrapped in bracketed paste sequences (`ESC[200~`...`ESC[201~`)
+- Shell receives content as literal text, newlines are not executed during paste
+- Disabled on terminal cleanup/exit
+
+### Alt+Enter (Literal Newline)
+
+| Input | Sequence | Behavior |
+|-------|----------|----------|
+| `Alt+Enter` | `ESC + \r` | Insert literal newline in shell (for multi-line command editing) |
+
 ## Rendering
 
 ### Process


### PR DESCRIPTION
## Summary

- Enable bracketed paste mode for proper multi-line paste handling (pasted content wrapped in `ESC[200~`...`ESC[201~` sequences)
- Add Alt+Enter support to send `ESC + CR` for literal newline insertion in shell
- Update requirements documentation for new PTY input handling features
- Add worktree context guidelines to CLAUDE.md to prevent cross-worktree edits

## Test plan

- [ ] Paste multi-line text (e.g., `echo "line1"\necho "line2"`) into terminal - lines should appear without immediate execution
- [ ] Press Enter after paste - commands should execute
- [ ] Press Alt+Enter while typing - should insert literal newline for multi-line command editing
- [ ] Verify regular Enter still executes commands normally
- [ ] Verify Ctrl+C, arrow keys, and function keys still work

🤖 Generated with [Claude Code](https://claude.ai/code)