### PR TITLE
feat(ui): use fixed 40-column sidebar width

### DIFF
--- a/reqs/7-side-nav.md
+++ b/reqs/7-side-nav.md
@@ -3,7 +3,7 @@
 ## Layout
 
 The sidebar occupies the left portion of the screen:
-- **Both panels visible**: 30% width
+- **Both panels visible**: Fixed 40 columns width
 - **Sidebar only**: 100% width
 - **Hidden**: 0% width (toggled via `Ctrl+b`)
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -305,10 +305,10 @@ impl App {
     fn calculate_layout(&self, area: Rect) -> Vec<Rect> {
         match (self.sidebar_visible, self.main_scene_visible) {
             (true, true) => {
-                // 30% sidebar, 70% main
+                // Fixed 40-column sidebar, main takes remaining space
                 Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
+                    .constraints([Constraint::Length(40), Constraint::Fill(1)])
                     .split(area)
                     .to_vec()
             }


### PR DESCRIPTION
## Summary
- Changed sidebar layout from percentage-based (30%) to fixed 40-column width
- Provides consistent sidebar width regardless of terminal size
- Updated requirements documentation to reflect the change

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo build --verbose` succeeds
- [x] `cargo test --verbose` passes (58 tests)
- [ ] Manual verification: Run the app and verify sidebar is fixed at 40 columns


🤖 Generated with [Claude Code](https://claude.com/claude-code)