### PR TITLE
feat(ui): change sidebar escape key from Esc to Ctrl+Esc

### DIFF
--- a/reqs/4-keybindings.md
+++ b/reqs/4-keybindings.md
@@ -9,7 +9,7 @@ Keys available regardless of context:
 | `?` | Toggle help overlay |
 | `Ctrl+b` | Toggle sidebar visibility |
 | `Ctrl+t` | Toggle terminal visibility |
-| `Esc` | Return to sidebar / close dialogs |
+| `Ctrl+Esc` | Return to sidebar / close help |
 
 ## Sidebar Context
 
@@ -32,7 +32,7 @@ When terminal is focused:
 
 | Key | Action |
 |-----|--------|
-| `Esc` | Return focus to sidebar |
+| `Ctrl+Esc` | Return focus to sidebar |
 | `Ctrl+b` | Toggle sidebar visibility |
 | `Ctrl+t` | Toggle terminal visibility |
 | All other keys | Forwarded to shell/PTY |

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -336,10 +336,10 @@ impl App {
         }
 
         // When focused on MainScene (PTY), forward most keys to the terminal
-        // Only Esc returns to sidebar, Ctrl+B/T toggle panels
+        // Only Ctrl+Esc returns to sidebar, Ctrl+B/T toggle panels
         if self.focus == Focus::MainScene {
             match key.code {
-                KeyCode::Esc => {
+                KeyCode::Esc if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     if self.show_help {
                         self.show_help = false;
                     } else {
@@ -385,7 +385,7 @@ impl App {
                 }
                 return;
             }
-            KeyCode::Esc => {
+            KeyCode::Esc if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 if self.show_help {
                     self.show_help = false;
                 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -46,8 +46,8 @@ pub fn render_help(frame: &mut Frame, area: Rect) {
             Span::raw("Toggle terminal"),
         ]),
         Line::from(vec![
-            Span::styled("  Esc     ", Style::default().fg(Color::Yellow)),
-            Span::raw("Return to sidebar / close help"),
+            Span::styled("  Ctrl+Esc", Style::default().fg(Color::Yellow)),
+            Span::raw(" Return to sidebar / close help"),
         ]),
         Line::from(""),
         Line::from(vec![Span::styled(
@@ -80,7 +80,7 @@ pub fn render_help(frame: &mut Frame, area: Rect) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            "Press ? or Esc to close",
+            "Press ? or Ctrl+Esc to close",
             Style::default().fg(Color::DarkGray),
         )),
     ];


### PR DESCRIPTION
## Summary
- Changed the key binding for returning to sidebar from plain `Esc` to `Ctrl+Esc`
- This prevents conflicts with terminal applications (like Claude) that need `Esc` for their own menu navigation
- Updated help overlay and requirements documentation

## Changes
- `src/ui/app.rs`: Updated key handlers to require `Ctrl+Esc` for sidebar return and help close
- `src/ui/help.rs`: Updated keyboard cheat sheet to show `Ctrl+Esc`
- `reqs/4-keybindings.md`: Updated requirements documentation

## Note
Confirmation dialogs and text input prompts still use plain `Esc` for cancel - these are modal overlays where `Esc` is the expected behavior and don't conflict with terminal usage.

## Test plan
- [ ] Build and run the application
- [ ] Focus terminal, verify plain `Esc` is now passed through to the PTY
- [ ] Verify `Ctrl+Esc` returns focus to sidebar
- [ ] Open help overlay with `?`, verify `Ctrl+Esc` closes it
- [ ] Verify confirmation dialogs and prompts still respond to plain `Esc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)