### PR TITLE
feat(ui): add text ellipsis for sidebar overflow

### DIFF
--- a/reqs/7-side-nav.md
+++ b/reqs/7-side-nav.md
@@ -32,6 +32,13 @@ Each room displays:
 2. **Room name**: User-given or auto-generated
 3. **Branch name**: Shown on second line with tree connector (`└─`)
 
+## Text Overflow
+
+When room names or branch names exceed the available sidebar width, they are truncated with an ellipsis (`…`):
+- Room names are truncated after accounting for the status icon prefix (2 characters)
+- Branch names are truncated after accounting for the tree connector prefix (5 characters)
+- Unicode characters are handled correctly using unicode width measurements
+
 ## Status Icons
 
 | Icon | Status | Color |


### PR DESCRIPTION
## Summary
- Added text truncation with ellipsis (`…`) for room names and branch names that exceed sidebar width
- Uses unicode width measurements to correctly handle multi-byte characters
- Added 4 unit tests for the truncation function
- Updated requirements documentation

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo build --verbose` succeeds
- [x] `cargo test --verbose` passes (62 tests, 4 new)
- [ ] Manual verification: Create a room with a long name or branch and verify ellipsis appears


🤖 Generated with [Claude Code](https://claude.com/claude-code)