### PR TITLE
feat(ui): add Ctrl+Delete shortcut to delete room without prompt

### DIFF
--- a/reqs/4-keybindings.md
+++ b/reqs/4-keybindings.md
@@ -24,6 +24,7 @@ When sidebar is focused:
 | `a` | Add room (interactive: prompts for name and branch) |
 | `A` | Add room (quick: auto-generated name, current branch) |
 | `Delete` | Delete room (shows confirmation dialog) |
+| `Ctrl+Delete` | Delete room immediately (no confirmation) |
 | `r` | Rename room (prompts for new name) |
 
 ## Terminal Context (MainScene)

--- a/reqs/9-room-lifecycle.md
+++ b/reqs/9-room-lifecycle.md
@@ -56,7 +56,9 @@ Depending on branch state:
 ## Delete Room
 
 ### Trigger
-Key: `d` on selected room
+
+- **Delete key**: Shows confirmation dialog before deleting
+- **Ctrl+Delete**: Deletes immediately without confirmation (use with caution)
 
 ### Confirmation Dialog
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -484,7 +484,13 @@ impl App {
                 self.create_room_silent();
             }
             KeyCode::Delete => {
-                self.start_room_deletion();
+                if key.modifiers.contains(KeyModifiers::CONTROL) {
+                    // Ctrl+Delete: delete without confirmation
+                    self.delete_room_immediate();
+                } else {
+                    // Delete: show confirmation dialog
+                    self.start_room_deletion();
+                }
             }
             KeyCode::Char('r') => {
                 self.start_room_rename();
@@ -810,6 +816,20 @@ impl App {
         };
 
         self.confirm = ConfirmState::start_delete(room_name, room_path, branch, dirty_status);
+    }
+
+    /// Delete the currently selected room immediately without confirmation.
+    fn delete_room_immediate(&mut self) {
+        let room = match self.selected_room() {
+            Some(r) => r,
+            None => {
+                self.status_message = Some("No room selected".to_string());
+                return;
+            }
+        };
+
+        let room_name = room.name.clone();
+        self.delete_room(&room_name);
     }
 
     /// Delete the room with the given name.


### PR DESCRIPTION
## Summary
- Added `Ctrl+Delete` keyboard shortcut to delete the selected room immediately without confirmation
- Regular `Delete` key still shows the confirmation dialog as before
- Updated keybindings and room lifecycle requirements documentation

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo build --verbose` succeeds
- [x] `cargo test --verbose` passes (58 tests)
- [ ] Manual verification: Test `Delete` shows confirmation, `Ctrl+Delete` deletes immediately


🤖 Generated with [Claude Code](https://claude.com/claude-code)