### PR TITLE
fix(ci): correct rustup component installation syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --component rustfmt clippy
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          source "$HOME/.cargo/env"
+          rustup component add rustfmt clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v5.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,10 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --component rustfmt clippy
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          source "$HOME/.cargo/env"
+          rustup component add rustfmt clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v5.0.2


### PR DESCRIPTION
## Summary
- Fix CI and release workflow failures caused by invalid `rustup-init` syntax
- The `--component` flag is not supported by `rustup-init`; components must be added separately using `rustup component add`

## Test plan
- [ ] Verify CI workflow passes on this PR
- [ ] After merge, verify release workflow can be triggered successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)