### PR TITLE
fix(ci): remove deprecated set-output command from release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -338,9 +338,11 @@ function setOutput(name: string, value: string): void {
       appendFileSync(outputFile, `${name}=${value}\n`);
     }
   }
-  console.log(
-    `::set-output:: ${name}=${value.split("\n")[0]}${value.includes("\n") ? "..." : ""}`
-  );
+  // Log output for debugging (truncate multiline values)
+  const displayValue = value.includes("\n")
+    ? `${value.split("\n")[0]}...`
+    : value;
+  console.log(`📤 Output: ${name}=${displayValue}`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix release workflow failure caused by deprecated `::set-output::` command syntax
- The release script was logging the old command format which GitHub Actions tried to parse, causing errors like: `Required field 'name' is missing in ##[set-output] command`
- The script already correctly writes to `$GITHUB_OUTPUT`, so the fix just changes the console log format

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, trigger a dry-run release to verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)