### PR TITLE
fix(ui): render inverse cursor with default colors

### DIFF
--- a/reqs/8-pseudoterminal.md
+++ b/reqs/8-pseudoterminal.md
@@ -31,6 +31,7 @@ Each room has an associated PTY session that provides an embedded terminal. The 
 - 256-color palette
 - RGB/TrueColor
 - Text attributes (bold, italic, underline, etc.)
+- Inverse video is rendered even when fg/bg are defaults (cursor visibility)
 - Cursor positioning
 - Cursor visibility
 - Scrollback navigation (1000 lines)


### PR DESCRIPTION
## Summary
- render inverse video as REVERSED when fg/bg are defaults
- preserve swap behavior for explicit fg/bg colors
- document inverse-video cursor requirement in PTY reqs