### PR TITLE
fix(ui): run post_enter only on PTY creation

### DIFF
--- a/reqs/10-operations-and-logging.md
+++ b/reqs/10-operations-and-logging.md
@@ -47,7 +47,7 @@ Plain text, one event per line:
 
 Hooks are executed in the PTY shell:
 - `post_create` runs after room creation (before `post_enter`)
-- `post_enter` runs when entering a room
+- `post_enter` runs when a room's PTY session is created
 
 ### Skipping
 

--- a/reqs/6-config.md
+++ b/reqs/6-config.md
@@ -24,7 +24,7 @@ Hooks are strings or arrays of strings. Each string is a command sent to the roo
 
 Supported keys:
 - `post_create`: runs immediately after creating a room
-- `post_enter`: runs immediately after entering a room (including after create)
+- `post_enter`: runs when a room's PTY session is created (including after create)
 
 ## Example Configuration
 

--- a/reqs/9-room-lifecycle.md
+++ b/reqs/9-room-lifecycle.md
@@ -19,7 +19,7 @@
    - Show a temporary INACTIVE entry with an animated yellow dot and `Creating...` label while creating
    - Refresh worktree list when creation completes
    - Auto-enter the new room (start PTY session)
-   - Run `post_create` hooks, then `post_enter` hooks (if configured)
+   - Run `post_create` hooks, then `post_enter` hooks on PTY creation (if configured)
 
 ### Quick Mode (Key: `A`)
 


### PR DESCRIPTION
## Summary
- run post_enter only when a PTY session is created
- update hook/lifecycle requirements wording accordingly

## Testing
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --verbose
- cargo test --verbose